### PR TITLE
feat: replace token deduplication with merge

### DIFF
--- a/Sources/FluidAudio/ASR/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/ChunkProcessor.swift
@@ -54,11 +54,11 @@ struct ChunkProcessor {
 
             // For chunks after the first, check for and remove duplicated token sequences
             if segmentIndex > 0 && !allTokens.isEmpty && !windowTokens.isEmpty {
-                let (deduped, removedCount) = manager.removeDuplicateTokenSequence(
+                let (merged, removedCount) = manager.mergeTokens(
                     previous: allTokens, current: windowTokens)
                 let adjustedTimestamps = Array(windowTimestamps.dropFirst(removedCount))
 
-                allTokens.append(contentsOf: deduped)
+                allTokens = merged
                 allTimestamps.append(contentsOf: adjustedTimestamps)
             } else {
                 allTokens.append(contentsOf: windowTokens)

--- a/Tests/FluidAudioTests/AsrManagerExtensionTests.swift
+++ b/Tests/FluidAudioTests/AsrManagerExtensionTests.swift
@@ -139,125 +139,123 @@ final class AsrManagerExtensionTests: XCTestCase {
         XCTAssertEqual(offset, 0)
     }
 
-    // MARK: - removeDuplicateTokenSequence Tests
+    // MARK: - mergeTokens Tests
 
-    func testRemoveDuplicateTokenSequenceNoDuplicates() {
+    func testMergeTokensNoDuplicates() {
         let previous = [1, 2, 3, 4, 5]
         let current = [6, 7, 8, 9, 10]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         XCTAssertEqual(deduped, current, "No duplicates should return original current")
         XCTAssertEqual(removedCount, 0, "Should not remove any tokens")
     }
 
-    func testRemoveDuplicateTokenSequenceWithOverlap() {
+    func testMergeTokensWithOverlap() {
         let previous = [1, 2, 3, 4, 5]
         let current = [3, 4, 5, 6, 7, 8]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         // Should remove [3, 4, 5] from the beginning of current
         XCTAssertEqual(deduped, [6, 7, 8], "Should remove overlapping tokens")
         XCTAssertEqual(removedCount, 3, "Should remove 3 tokens")
     }
 
-    func testRemoveDuplicateTokenSequencePunctuation() {
+    func testMergeTokensPunctuation() {
         let previous = [1, 2, 3, 7883]  // 7883 is period
         let current = [7883, 4, 5, 6]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         // Should remove duplicate period
         XCTAssertEqual(deduped, [4, 5, 6], "Should remove duplicate punctuation")
         XCTAssertEqual(removedCount, 1, "Should remove 1 punctuation token")
     }
 
-    func testRemoveDuplicateTokenSequenceQuestionMark() {
+    func testMergeTokensQuestionMark() {
         let previous = [1, 2, 7952]  // 7952 is question mark
         let current = [7952, 3, 4]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         XCTAssertEqual(deduped, [3, 4], "Should remove duplicate question mark")
         XCTAssertEqual(removedCount, 1, "Should remove 1 token")
     }
 
-    func testRemoveDuplicateTokenSequenceExclamation() {
+    func testMergeTokensExclamation() {
         let previous = [1, 2, 7948]  // 7948 is exclamation
         let current = [7948, 3, 4]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         XCTAssertEqual(deduped, [3, 4], "Should remove duplicate exclamation")
         XCTAssertEqual(removedCount, 1, "Should remove 1 token")
     }
 
-    func testRemoveDuplicateTokenSequenceEmptyPrevious() {
+    func testMergeTokensEmptyPrevious() {
         let previous: [Int] = []
         let current = [1, 2, 3, 4]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         XCTAssertEqual(deduped, current, "Empty previous should return original current")
         XCTAssertEqual(removedCount, 0, "Should not remove any tokens")
     }
 
-    func testRemoveDuplicateTokenSequenceEmptyCurrent() {
+    func testMergeTokensEmptyCurrent() {
         let previous = [1, 2, 3, 4]
         let current: [Int] = []
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         XCTAssertEqual(deduped, current, "Empty current should return empty array")
         XCTAssertEqual(removedCount, 0, "Should not remove any tokens")
     }
 
-    func testRemoveDuplicateTokenSequenceShortSequences() {
+    func testMergeTokensShortSequences() {
         let previous = [1, 2]
         let current = [2, 3]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
-        // Short sequences (< 3 tokens) should not be processed for overlap
-        XCTAssertEqual(deduped, current, "Short sequences should return original")
-        XCTAssertEqual(removedCount, 0, "Should not remove any tokens")
+        XCTAssertEqual(deduped, [3], "Should remove overlapping token")
+        XCTAssertEqual(removedCount, 1, "Should remove 1 token")
     }
 
-    func testRemoveDuplicateTokenSequenceMaxOverlap() {
+    func testMergeTokensMaxOverlap() {
         // Test with overlap longer than default maxOverlap (12)
         let previous = Array(1...20)
         let current = Array(10...25)  // 10-21 overlaps with previous
 
-        let (_, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (_, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         // Should find some overlap within maxOverlap limit
         XCTAssertGreaterThan(removedCount, 0, "Should find some overlap")
         XCTAssertLessThanOrEqual(removedCount, 12, "Should not exceed maxOverlap")
     }
 
-    func testRemoveDuplicateTokenSequencePartialOverlap() {
+    func testMergeTokensPartialOverlap() {
         let previous = [10, 11, 12, 13, 14]
         let current = [12, 13, 14, 15, 16]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+        let (deduped, removedCount) = manager.mergeTokens(previous: previous, current: current)
 
         // Should remove [12, 13, 14] from current
         XCTAssertEqual(deduped, [15, 16], "Should remove partial overlap")
         XCTAssertEqual(removedCount, 3, "Should remove 3 overlapping tokens")
     }
 
-    func testRemoveDuplicateTokenSequenceCustomMaxOverlap() {
+    func testMergeTokensCustomMaxOverlap() {
         let previous = [1, 2, 3, 4, 5, 6]
         let current = [4, 5, 6, 7, 8, 9]
 
-        let (deduped, removedCount) = manager.removeDuplicateTokenSequence(
+        let (deduped, removedCount) = manager.mergeTokens(
             previous: previous, current: current, maxOverlap: 2
         )
 
-        // With maxOverlap=2, should not find the 3-token overlap but only 2-token overlap
-        XCTAssertEqual(deduped, [6, 7, 8, 9], "Should not find overlap with small maxOverlap \(deduped)")
-        XCTAssertEqual(removedCount, 2, "Should not remove any tokens with small maxOverlap")
+        XCTAssertEqual(deduped, [6, 7, 8, 9], "Should not find overlap with small maxOverlap")
+        XCTAssertEqual(removedCount, 2, "Should remove 2 tokens")
     }
 
     // MARK: - Performance Tests
@@ -281,13 +279,13 @@ final class AsrManagerExtensionTests: XCTestCase {
         }
     }
 
-    func testRemoveDuplicateTokenSequencePerformance() {
+    func testMergeTokensPerformance() {
         let previous = Array(1...1000)
         let current = Array(990...1500)  // 10-token overlap
 
         measure {
             for _ in 0..<1000 {
-                _ = manager.removeDuplicateTokenSequence(previous: previous, current: current)
+                _ = manager.mergeTokens(previous: previous, current: current)
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace token deduplication with merge logic using longest contiguous overlap and LCS fallback
- update chunk and streaming processors to use new merging function
- refresh tests for mergeTokens behavior

## Testing
- `swift build` *(fails: no such module 'Accelerate')*
- `swift test` *(fails: no such module 'Accelerate')*

------
https://chatgpt.com/codex/tasks/task_e_68b5380354888333b07a13aa98a730cf